### PR TITLE
Updating the link to `Running the router`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ address, and then curl will show your new message:
     $ curl 10.1.0.2:8888
      Hello World!
 
-To test from external network, you need to create router. Please refer to [Running the router](https://github.com/openshift/origin/blob/master/docs/routing.md)
+To test from external network, you need to create router. Please refer to [Running the router](https://github.com/openshift/router)
 
 The container doesn't expose any ports, this will require you to expose it manually.
 For example:


### PR DESCRIPTION
The link [Running the router](https://github.com/openshift/origin/blob/master/docs/routing.md) does not exist anymore:
[commit](https://github.com/openshift/origin/commit/d93356b3349b359ca28c8c2c6c03817b1eb9729d)
`The router has been moved to openshift/router 
Delete the old code
Clayton Coleman committed on Dec 17, 2018
`
My assumption is, that this should be the new one:
https://github.com/openshift/router